### PR TITLE
PNGフォールバック確認用のログを追加

### DIFF
--- a/app/routes/app-home.tsx
+++ b/app/routes/app-home.tsx
@@ -175,8 +175,14 @@ async function compressImage(file: File): Promise<Blob> {
       ctx.drawImage(img, 0, 0, width, height);
       canvas.toBlob(
         (blob) => {
-          if (blob) resolve(blob);
-          else reject(new Error("Image compression failed"));
+          if (blob) {
+            console.log(
+              `[compressImage] type=${blob.type} size=${(blob.size / 1024 / 1024).toFixed(2)}MB (${width}×${height}px)`,
+            );
+            resolve(blob);
+          } else {
+            reject(new Error("Image compression failed"));
+          }
         },
         "image/webp",
         0.82,


### PR DESCRIPTION
## Summary

- `canvas.toBlob('image/webp')` が PNG にフォールバックしているかどうかを確認するためのログを追加
- ブラウザコンソールに `[compressImage] type=image/webp size=0.42MB (1920×1440px)` 形式で出力
- `type=image/png` が出ていれば PNG フォールバックが原因と確定できる

## Test plan

- [ ] 写真をアップロードしてブラウザコンソールにログが出ることを確認
- [ ] `type` フィールドが `image/webp` か `image/png` かを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)