### PR TITLE
履歴画面（カレンダービュー）を実装

### DIFF
--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -27,13 +27,6 @@ function formatJapaneseDate(date: Date) {
 const navItems = [
   { to: "/app", label: "ホーム", icon: "🏠", end: true, disabled: false },
   { to: "/app/history", label: "履歴", icon: "📊", end: false, disabled: false },
-  {
-    to: "/app/settings",
-    label: "設定",
-    icon: "⚙️",
-    end: false,
-    disabled: false,
-  },
 ];
 
 export default function AppLayout() {


### PR DESCRIPTION
## Summary

- ボトムナビから重複していた「設定」タブを削除（ヘッダーの⚙️アイコンで代替）
- [ ] ボトムナビに「ホーム」「履歴」の2タブのみ表示される
