### PR TITLE
feat: 設定画面に感想・要望フォームリンクを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-anon-key-here
 CRON_SECRET=your-cron-secret-here
 # Supabase Edge Functionsのシークレット
 CLEANUP_SECRET=your-cleanup-secret-here
+
+# GoogleフォームのURL
+GOOGLE_FORM_URL=https://your-google-form-url-here

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Claude
 settings.local.json
+
+# Vercel
+.vercel/

--- a/app/routes/app-settings.tsx
+++ b/app/routes/app-settings.tsx
@@ -17,7 +17,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     return redirect("/login", { headers: responseHeaders });
   }
 
-  return data({ email: user.email ?? "" }, { headers: responseHeaders });
+  return data(
+    {
+      email: user.email ?? "",
+      googleFormUrl: process.env.GOOGLE_FORM_URL ?? "",
+    },
+    { headers: responseHeaders }
+  );
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -28,7 +34,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function AppSettings() {
-  const { email } = useLoaderData<typeof loader>();
+  const { email, googleFormUrl } = useLoaderData<typeof loader>();
 
   return (
     <div className="flex flex-col gap-6 pt-2">
@@ -40,6 +46,22 @@ export default function AppSettings() {
         <p className="text-sm text-slate-500">メールアドレス</p>
         <p className="text-base text-slate-700 font-medium mt-0.5">{email}</p>
       </section>
+
+      {/* 感想・要望 */}
+      {googleFormUrl && (
+        <section className="bg-white rounded-2xl shadow-sm px-5 py-2">
+          <a
+            href={googleFormUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full text-left py-3 text-base text-slate-700 font-medium flex items-center justify-between"
+          >
+            感想・要望を送る
+            <span className="text-xs text-slate-400 mr-1">Googleフォームが開きます</span>
+            <span className="text-slate-400">›</span>
+          </a>
+        </section>
+      )}
 
       {/* ログアウト */}
       <section className="bg-white rounded-2xl shadow-sm px-5 py-2">


### PR DESCRIPTION
## Summary

- `app/routes/app-settings.tsx` の loader で `GOOGLE_FORM_URL` 環境変数を返すよう変更
- 設定画面にGoogleフォームへのリンクセクションを追加（アカウント情報 → **感想・要望** → ログアウトの順）
- `GOOGLE_FORM_URL` が未設定の場合はセクション自体を非表示にする条件レンダリング
- `.env.example` に `GOOGLE_FORM_URL` のサンプルを追記

## Test plan

- [x] `/app/settings` にアクセスし「感想・要望を送る」リンクが表示されることを確認
- [x] リンクをクリックするとGoogleフォームが新しいタブで開くことを確認
- [x] `GOOGLE_FORM_URL` が未設定の場合はセクションが非表示になることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)