### PR TITLE
ci: Claude ActionのPRベースブランチをdevelopに設定

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          base_branch: develop
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -57,5 +58,5 @@ jobs:
           #     }
           #   }
           claude_args: |
-              --allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
-              --disallowedTools "Bash(rm *),Bash(curl *)"
+            --allowedTools "Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
+            --disallowedTools "Bash(rm *),Bash(curl *)"


### PR DESCRIPTION
## Summary
- `claude-code-action` の `base_branch` パラメータに `develop` を指定
- これにより、ワークフローで作成されるPRのベースブランチが `develop` になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)