### PR TITLE
ci: npm run testをAllowedToolsに追加、PRのターゲットブランチをdevelopに指定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       "Bash(npm install:*)",
       "Bash(npm run build:*)",
       "Bash(npm run dev)",
+      "Bash(npm run test:*)",
       "Bash(git checkout:*)",
       "Bash(git status:*)",
       "Bash(git pull:*)",

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -35,7 +35,9 @@
 
 ## プルリクエスト作成
 
-`gh pr create` のボディは**必ずHereDocumentを使う**こと：
+- プルリクエストは常に `develop` ブランチへのマージを対象として作成すること（`main` ではなく）。
+
+- `gh pr create` のボディは**必ずHereDocumentを使う**こと：
 
 ```bash
 gh pr create --title "タイトル" --body "$(cat <<'EOF'


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `Bash(npm run test:*)` を AllowedTools に追加
- `docs/instructions.md` にPRは常に `develop` ブランチへのマージを対象とする旨の指示を追加

## Test plan
- [x] `npm run test` が Claude から実行できることを確認
- [x] PR作成時に `develop` がベースブランチになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)