### PR TITLE
ci(dependabot): react-router 関連パッケージを1つのPRにまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+    groups:
+      # react-router関連のパッケージをまとめる
+      react-router:
+        patterns:
+          - "react-router"
+          - "@react-router/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- Dependabot が `react-router`・`@react-router/*` を個別にPRを作成してしまい、ピア依存関係の不整合でCIが失敗していた問題を修正
- `groups` 設定を追加し、react-router 関連パッケージを1つのPRにまとめるようにした

## Test plan

- [ ] 次回 Dependabot が react-router 系の更新を検出したとき、1つのPRにまとめられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)