### PR TITLE
fix: 日付表示のタイムゾーンをUTCからJSTに修正

### DIFF
--- a/app/lib/date.ts
+++ b/app/lib/date.ts
@@ -13,6 +13,15 @@ export function jstMonthBounds(year: number, month: number) {
   return { start, end };
 }
 
+/** JST の今日の境界を UTC の Date として返す */
+export function jstTodayBounds() {
+  const nowJSTMs = Date.now() + JST_OFFSET_MS;
+  const todayJSTMs = nowJSTMs - (nowJSTMs % (24 * 60 * 60 * 1000));
+  const start = new Date(todayJSTMs - JST_OFFSET_MS);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
 /** JST の週（月曜始まり）境界を UTC の Date として返す。
  *  weekOffset=0 → 今週, weekOffset=-1 → 先週 */
 export function jstWeekBounds(weekOffset = 0) {

--- a/app/routes/app-home.tsx
+++ b/app/routes/app-home.tsx
@@ -2,6 +2,7 @@ import { data, redirect, useFetcher, useLoaderData, Link } from "react-router";
 import { useRef, useState, useEffect } from "react";
 import type { Route } from "./+types/app-home";
 import { createSupabaseClient } from "~/lib/supabase.server";
+import { jstTodayBounds } from "~/lib/date";
 
 type CheckItem = {
   id: string;
@@ -23,10 +24,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     return redirect("/login", { headers: responseHeaders });
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const tomorrowStart = new Date(todayStart);
-  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+  const { start: todayStart, end: tomorrowStart } = jstTodayBounds();
 
   const [{ data: items }, { data: todayLogs }] = await Promise.all([
     supabase

--- a/app/routes/app-item-detail.tsx
+++ b/app/routes/app-item-detail.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/app-item-detail";
 import { createSupabaseClient } from "~/lib/supabase.server";
+import { jstTodayBounds } from "~/lib/date";
 
 type Log = {
   id: string;
@@ -22,10 +23,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const itemId = params.id as string;
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const tomorrowStart = new Date(todayStart);
-  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+  const { start: todayStart, end: tomorrowStart } = jstTodayBounds();
 
   const [{ data: item }, { data: rawLogs }] = await Promise.all([
     supabase

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, Outlet, NavLink } from "react-router";
 import type { Route } from "./+types/app";
 import { createSupabaseClient } from "~/lib/supabase.server";
+import { JST_OFFSET_MS } from "~/lib/date";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const responseHeaders = new Headers();
@@ -16,11 +17,12 @@ export async function loader({ request }: Route.LoaderArgs) {
   return data({ user }, { headers: responseHeaders });
 }
 
-function formatJapaneseDate(date: Date) {
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+function formatJapaneseDate() {
+  const nowJST = new Date(Date.now() + JST_OFFSET_MS);
+  const month = nowJST.getUTCMonth() + 1;
+  const day = nowJST.getUTCDate();
   const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  const weekday = weekdays[date.getDay()];
+  const weekday = weekdays[nowJST.getUTCDay()];
   return `${month}月${day}日（${weekday}）`;
 }
 
@@ -30,7 +32,7 @@ const navItems = [
 ];
 
 export default function AppLayout() {
-  const dateLabel = formatJapaneseDate(new Date());
+  const dateLabel = formatJapaneseDate();
 
   return (
     <div className="h-dvh bg-slate-50 flex flex-col max-w-lg mx-auto">


### PR DESCRIPTION
## 概要

ホーム画面・アイテム詳細画面の「今日」クエリ範囲おUTC基準で計算されていたため、JST 00:00〜09:00の間に日付表示やカウントが前日のものになっていた問題を修正。

Closes #83

Generated with [Claude Code](https://claude.ai/code)